### PR TITLE
Implement basic DB initialization with default admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # ventas
+
+This project includes a small Flask server backed by a SQLite database.
+
+## Default credentials
+
+After starting the application and visiting `/init`, a default administrator account is created with the following credentials:
+
+- **Username:** `admin`
+- **Password:** `admin`
+
+These credentials are added only when the database has no existing users.

--- a/db.py
+++ b/db.py
@@ -1,0 +1,46 @@
+import sqlite3
+from pathlib import Path
+
+DB_PATH = Path("ventas.db")
+
+
+def init_db():
+    """Initialize the database and insert default admin if empty."""
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+
+    # Create tables if they don't exist
+    cur.execute(
+        """CREATE TABLE IF NOT EXISTS roles (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT UNIQUE
+            )"""
+    )
+    cur.execute(
+        """CREATE TABLE IF NOT EXISTS users (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                username TEXT UNIQUE,
+                password TEXT,
+                role_id INTEGER,
+                FOREIGN KEY(role_id) REFERENCES roles(id)
+            )"""
+    )
+    conn.commit()
+
+    # Check if any user exists
+    cur.execute("SELECT COUNT(*) FROM users")
+    count = cur.fetchone()[0]
+    if count == 0:
+        # Insert default admin role and user
+        cur.execute("INSERT INTO roles (name) VALUES (?)", ("admin",))
+        role_id = cur.lastrowid
+        cur.execute(
+            "INSERT INTO users (username, password, role_id) VALUES (?,?,?)",
+            ("admin", "admin", role_id),
+        )
+        conn.commit()
+
+    conn.close()
+
+if __name__ == "__main__":
+    init_db()

--- a/server.py
+++ b/server.py
@@ -1,0 +1,14 @@
+from flask import Flask
+from db import init_db
+
+app = Flask(__name__)
+
+
+@app.route("/init")
+def init_route():
+    init_db()
+    return "Database initialized", 200
+
+
+if __name__ == "__main__":
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- create `db.py` with `init_db` function that creates tables and seeds an admin user when none exist
- add a minimal Flask server exposing `/init` to trigger the database setup
- document the default admin credentials in `README.md`

## Testing
- `python3 -m py_compile db.py server.py`


------
https://chatgpt.com/codex/tasks/task_e_685cb27e2b1c8331ac2e5e12bce59b33